### PR TITLE
Unify width of roadmap containers to 80%

### DIFF
--- a/themes/nav-community-v1/static/css/style.css
+++ b/themes/nav-community-v1/static/css/style.css
@@ -3408,6 +3408,7 @@ ul li.cat-item a {
 .roadmap-table {
   display: table;
   position: relative;
+  width: 80%;
 }
 
 .roadmap-table:last-child .roadmap-connector {

--- a/themes/nav-community-v1/static/css/style.css
+++ b/themes/nav-community-v1/static/css/style.css
@@ -3408,7 +3408,7 @@ ul li.cat-item a {
 .roadmap-table {
   display: table;
   position: relative;
-  width: 80%;
+  width: 100%;
 }
 
 .roadmap-table:last-child .roadmap-connector {


### PR DESCRIPTION
Currently the progress bars are only as long as the roadmap containers which vary in width. By setting them to 80% (or any percent value) they are all equally long and easier to compare.