### PR TITLE
Fixing overflows on /projects and /roadmap

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -23,7 +23,7 @@ order_by: "default"
     linkBgColor="#523971"
     gradient=""
     fontColor="#FFF">}}
-
+	<body class="projects">
     <p>There is a whole eco-system of software which developers have created to operate on or alongside the NavCoin protocol. All software the NavCoin Core developers create is also free and open-source.</p>
     <p>Here you can find more information about all the awesome projects which have been, or are being built by the NavCoin community.</p>
 {{< /left_image_section >}}

--- a/content/projects/order-by-last-updated.md
+++ b/content/projects/order-by-last-updated.md
@@ -23,7 +23,7 @@ order_by: "lastmod"
     linkBgColor="#523971"
     gradient=""
     fontColor="#FFF">}}
-
+	<body class="projects">
     <p>There is a whole eco-system of software which developers have created to operate on or alongside the NavCoin protocol. All software the NavCoin Core developers create is also free and open-source.</p>
     <p>Here you can find more information about all the awesome projects which have been, or are being built by the NavCoin community.</p>
 {{< /left_image_section >}}

--- a/content/projects/order-by-progress.md
+++ b/content/projects/order-by-progress.md
@@ -23,7 +23,7 @@ order_by: "progress"
     linkBgColor="#523971"
     gradient=""
     fontColor="#FFF">}}
-
+	<body class="projects">
     <p>There is a whole eco-system of software which developers have created to operate on or alongside the NavCoin protocol. All software the NavCoin Core developers create is also free and open-source.</p>
     <p>Here you can find more information about all the awesome projects which have been, or are being built by the NavCoin community.</p>
 {{< /left_image_section >}}

--- a/content/roadmap/index.md
+++ b/content/roadmap/index.md
@@ -15,6 +15,7 @@ type: "roadmap"
     btn1Link="/get-involved"
     btn1Txt="Contribute to NavCoin"
     fontColor="#FFF">}}
+	<body class="roadmap-row"> 
     <p>Cryptocurrencies are complicated, and it’s NavCoin’s mission to change that. As a community we are striving to make NavCoin the most usable cryptocurrency on the planet.</p>
     <p>NavCoin’s community roadmap continues that journey. Together we are laying the foundation for NavCoin to be an industry-leading cryptocurrency, by building better money.</p>
 {{< /left_image_section >}}

--- a/themes/nav-community-v1/layouts/partials/footer.html
+++ b/themes/nav-community-v1/layouts/partials/footer.html
@@ -12,17 +12,17 @@
                     </div>
                     <p>NavCoin released under the <a href="https://opensource.org/licenses/mit-license.php">MIT license</a></p>
                     <div class="themeix-social-area">
-                        <a class="themeix-tool" href="">
+                        <a class="themeix-tool" href="https://twitter.com/NavCoin">
                             <i class="fa fa-twitter"></i>
                             <div id="colorbox" class="themeix-color twitter-color"></div>
                         </a>
-                        <a class="themeix-tool" href="">
+                        <a class="themeix-tool" href="https://www.facebook.com/NavCoin/">
                             <i class="fa fa-facebook"></i>
                             <div id="colorboxs" class="themeix-color facebook-color"></div>
                         </a>
-                        <a class="themeix-tool" href="">
-                            <i class="fa fa-google-plus"></i>
-                            <div id="colorboxss" class="themeix-color google-color"></div>
+                        <a class="themeix-tool" href="https://www.reddit.com/r/NavCoin">
+                            <i class="fa fa-reddit"></i>
+                            <div id="colorboxss" class="themeix-color reddit-color"></div>
                         </a>
                     </div>
                 </div>

--- a/themes/nav-community-v1/static/css/style.css
+++ b/themes/nav-community-v1/static/css/style.css
@@ -1580,6 +1580,33 @@ textarea:-moz-placeholder {
 .inner-section {
     color: #ffffff;
 }
+
+.themeix-tool{
+	scale: 0.9;
+}
+.themeix-tool:hover{
+	transform: scale(0.9)!important;
+	-webkit-animation: social 1s;
+    animation: social 1s;
+}
+@-webkit-keyframes social {
+      0% { transform: scale(0.9); }
+	 50% { transform: scale(1); }
+    100% { transform: scale(0.9); }
+}
+
+@keyframes social {
+       0% { transform: scale(0.9); }
+	 50% { transform: scale(1); }
+    100% { transform: scale(0.9); }
+}
+
+a.themeix-tool .fa {
+    color: #FFFFFF;
+    font-size: 24px;
+    text-indent: .6px;
+}
+
 /* ==========================================
            18. scrollUP
    ========================================== */
@@ -3409,15 +3436,6 @@ ul li.cat-item a {
   display: table;
   position: relative;
   width: 100%;
-}
-
-body.roadmap-row .row, body.projects .row:nth-of-type(2) {
-	margin-left: 0px;
-	margin-right: 0px;
-}
-
-.col-sm-12 {
-	padding: 0px;
 }
 
 .roadmap-table:last-child .roadmap-connector {

--- a/themes/nav-community-v1/static/css/style.css
+++ b/themes/nav-community-v1/static/css/style.css
@@ -3408,6 +3408,16 @@ ul li.cat-item a {
 .roadmap-table {
   display: table;
   position: relative;
+  width: 100%;
+}
+
+body.roadmap-row .row, body.projects .row:nth-of-type(2) {
+	margin-left: 0px;
+	margin-right: 0px;
+}
+
+.col-sm-12 {
+	padding: 0px;
 }
 
 .roadmap-table:last-child .roadmap-connector {


### PR DESCRIPTION
both pages currently overflow because of 30px of margin added to .row. This fixes this issue by removing the margin from those pages in particular (requires a html class to be added to the pages so I can address them in CSS (I think?)) 

![image](https://user-images.githubusercontent.com/33290035/38380203-529b8070-3903-11e8-9698-a8bb1533531c.png)

